### PR TITLE
Enable all inventory type feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
+# Ecplise IDE
+.classpath
+.settings/
+.project
+
 # User-specific stuff
 .idea/
 

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
@@ -27,93 +27,117 @@ import static com.artillexstudios.axshulkers.AxShulkers.CONFIG;
 import static com.artillexstudios.axshulkers.AxShulkers.MESSAGES;
 
 public class ShulkerOpenListener implements Listener {
-    private final HashMap<UUID, Long> cds = new HashMap<>();
+	private final HashMap<UUID, Long> cds = new HashMap<>();
 
-    @EventHandler
-    public void onInteract(@NotNull PlayerInteractEvent event) {
-        if (ShulkerUtils.hasShulkerOpen(event.getPlayer()) != null && event.getAction() != Action.LEFT_CLICK_AIR) {
-            event.getPlayer().closeInventory();
-        }
+	@EventHandler
+	public void onInteract(@NotNull PlayerInteractEvent event) {
+		if (ShulkerUtils.hasShulkerOpen(event.getPlayer()) != null && event.getAction() != Action.LEFT_CLICK_AIR) {
+			event.getPlayer().closeInventory();
+		}
 
-        if (event.getAction() != Action.RIGHT_CLICK_AIR) return;
+		if (event.getAction() != Action.RIGHT_CLICK_AIR)
+			return;
 
-        final Player player = event.getPlayer();
-        if (openShulker(player, player.getInventory().getItemInMainHand())) event.setCancelled(true);
-    }
+		final Player player = event.getPlayer();
+		if (openShulker(player, player.getInventory().getItemInMainHand()))
+			event.setCancelled(true);
+	}
 
-    @EventHandler (priority = EventPriority.LOW)
-    public void onShulkerClick(@NotNull InventoryClickEvent event) {
-        if (!event.getClick().equals(ClickType.RIGHT)) return;
-        if (!CONFIG.getBoolean("opening-from-inventory.enabled")) return;
+	@EventHandler(priority = EventPriority.LOW)
+	public void onShulkerClick(@NotNull InventoryClickEvent event) {
+		if (!event.getClick().equals(ClickType.RIGHT))
+			return;
+		if (!CONFIG.getBoolean("opening-from-inventory.enabled"))
+			return;
 
-        final Player player = (Player) event.getWhoClicked();
-        if (event.getClickedInventory() != null && !event.getClickedInventory().equals(event.getWhoClicked().getInventory())) {
-            if (!event.getClickedInventory().equals(event.getWhoClicked().getEnderChest())) return;
-            if (!CONFIG.getBoolean("opening-from-inventory.open-from-enderchest")) return;
-        }
+		final Player player = (Player) event.getWhoClicked();
+		if (event.getClickedInventory() != null
+				&& !event.getClickedInventory().equals(event.getWhoClicked().getInventory())) {
+			if (CONFIG.getBoolean("enable-shulker-opening-in-all-inventory-type")) {
+				if (!CONFIG.getBoolean("opening-from-inventory.open-from-enderchest")
+						&& event.getClickedInventory().equals(event.getWhoClicked().getEnderChest()))
+					return;
+			} else {
+				if (!event.getClickedInventory().equals(event.getWhoClicked().getEnderChest()))
+					return;
+				if (!CONFIG.getBoolean("opening-from-inventory.open-from-enderchest")
+						&& event.getClickedInventory().equals(event.getWhoClicked().getEnderChest()))
+					return;
+			}
+		}
 
-        if (event.getView().getTopInventory().getType().equals(InventoryType.SHULKER_BOX)) {
-            for (Shulkerbox shulkerbox : Shulkerboxes.getShulkerMap().values()) {
-                if (!shulkerbox.getShulkerInventory().equals(event.getView().getTopInventory())) continue;
-                if (!shulkerbox.getUUID().equals(ShulkerUtils.getShulkerUUID(event.getCurrentItem()))) continue;
+		if (event.getView().getTopInventory().getType().equals(InventoryType.SHULKER_BOX)) {
+			for (Shulkerbox shulkerbox : Shulkerboxes.getShulkerMap().values()) {
+				if (!shulkerbox.getShulkerInventory().equals(event.getView().getTopInventory()))
+					continue;
+				if (!shulkerbox.getUUID().equals(ShulkerUtils.getShulkerUUID(event.getCurrentItem())))
+					continue;
 
-                event.setCancelled(true);
-                AxShulkers.getFoliaLib().getScheduler().runNextTick(t -> {
-                    event.getWhoClicked().closeInventory();
-                });
-                return;
-            }
-        }
+				event.setCancelled(true);
+				AxShulkers.getFoliaLib().getScheduler().runNextTick(t -> {
+					event.getWhoClicked().closeInventory();
+				});
+				return;
+			}
+		}
 
-        if (event.getCurrentItem() == null) return;
-        if (openShulker(player, event.getCurrentItem())) event.setCancelled(true);
-    }
+		if (event.getCurrentItem() == null)
+			return;
+		if (openShulker(player, event.getCurrentItem()))
+			event.setCancelled(true);
+	}
 
-    private boolean openShulker(@NotNull Player player, @NotNull ItemStack it) {
-        if (!player.hasPermission("axshulkers.use")) return false;
-        if (!ShulkerUtils.isShulker(it)) return false;
-        if (it.getAmount() > 1) {
-            it.setAmount(1);
-            return false;
-        }
+	private boolean openShulker(@NotNull Player player, @NotNull ItemStack it) {
+		if (!player.hasPermission("axshulkers.use"))
+			return false;
+		if (!ShulkerUtils.isShulker(it))
+			return false;
+		if (it.getAmount() > 1) {
+			it.setAmount(1);
+			return false;
+		}
 
-        if (CONFIG.getBoolean("disable-shulker-opening")) return false;
+		if (CONFIG.getBoolean("disable-shulker-opening"))
+			return false;
 
-        if (CONFIG.getStringList("blacklisted-worlds").contains(player.getWorld().getName())) {
-            MessageUtils.sendMsgP(player, "errors.blacklisted-world");
-            return false;
-        }
+		if (CONFIG.getStringList("blacklisted-worlds").contains(player.getWorld().getName())) {
+			MessageUtils.sendMsgP(player, "errors.blacklisted-world");
+			return false;
+		}
 
-        if (cds.containsKey(player.getUniqueId()) && System.currentTimeMillis() - cds.get(player.getUniqueId()) < CONFIG.getLong("open-cooldown-milliseconds")) {
-            final Map<String, String> map = new HashMap<>();
-            map.put("%seconds%", Long.toString((CONFIG.getLong("open-cooldown-milliseconds") - System.currentTimeMillis() + cds.get(player.getUniqueId())) / 1000L + 1));
-            MessageUtils.sendMsgP(player, "cooldown", map);
-            return false;
-        }
+		if (cds.containsKey(player.getUniqueId()) && System.currentTimeMillis() - cds.get(player.getUniqueId()) < CONFIG
+				.getLong("open-cooldown-milliseconds")) {
+			final Map<String, String> map = new HashMap<>();
+			map.put("%seconds%", Long.toString((CONFIG.getLong("open-cooldown-milliseconds")
+					- System.currentTimeMillis() + cds.get(player.getUniqueId())) / 1000L + 1));
+			MessageUtils.sendMsgP(player, "cooldown", map);
+			return false;
+		}
 
-        cds.put(player.getUniqueId(), System.currentTimeMillis());
+		cds.put(player.getUniqueId(), System.currentTimeMillis());
 
-        final String name = ShulkerUtils.getShulkerName(it);
+		final String name = ShulkerUtils.getShulkerName(it);
 
-        AxShulkers.getFoliaLib().getScheduler().runAtLocation(player.getLocation(), t -> {
-            final Shulkerbox shulkerbox = Shulkerboxes.getShulker(it, name);
-            if (shulkerbox == null) return;
-            if (player.getOpenInventory().getTopInventory().getType().equals(InventoryType.SHULKER_BOX)) {
-                shulkerbox.close();
-            }
+		AxShulkers.getFoliaLib().getScheduler().runAtLocation(player.getLocation(), t -> {
+			final Shulkerbox shulkerbox = Shulkerboxes.getShulker(it, name);
+			if (shulkerbox == null)
+				return;
+			if (player.getOpenInventory().getTopInventory().getType().equals(InventoryType.SHULKER_BOX)) {
+				shulkerbox.close();
+			}
 
-            ShulkerUtils.clearShulkerContents(it);
+			ShulkerUtils.clearShulkerContents(it);
 
-            shulkerbox.setItem(it);
-            shulkerbox.updateReference();
-            shulkerbox.openShulkerFor(player);
+			shulkerbox.setItem(it);
+			shulkerbox.updateReference();
+			shulkerbox.openShulkerFor(player);
 
-            MessageUtils.sendMsgP(player, "open.message", Collections.singletonMap("%name%", shulkerbox.getTitle()));
+			MessageUtils.sendMsgP(player, "open.message", Collections.singletonMap("%name%", shulkerbox.getTitle()));
 
-            if (!MESSAGES.getString("open.sound").isEmpty()) {
-                player.playSound(player.getLocation(), Sound.valueOf(MESSAGES.getString("open.sound")), 1f, 1f);
-            }
-        });
-        return true;
-    }
+			if (!MESSAGES.getString("open.sound").isEmpty()) {
+				player.playSound(player.getLocation(), Sound.valueOf(MESSAGES.getString("open.sound")), 1f, 1f);
+			}
+		});
+		return true;
+	}
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -42,6 +42,9 @@ disable-shulker-dispensing: false
 # if this is true, the shulker will be closed if the player moves
 disable-moving-while-open: false
 
+# If this is true then player can open shulkers from all type of inventory (chest, trapped chest, dispenser, etc.)
+enable-shulker-opening-in-all-inventory-type: false
+
 # if this is true then shulkers will be immune to cactus, lava, fire, etc..
 undestoryable-shulkers: false
 


### PR DESCRIPTION
## Purpose of the pull

Added feature to enable/disable if shulkers can be opened in all inventory type (chest, dispenser, crafting table, etc.)

I removed the rules `IF the feature is enabled THEN IF clicked inventory is not an enderchest THEN return` and added `IF click in enderchest is disabled AND if the clicked inventory is an enderchest THEN return`

I hope my code is clear and my explanations too !

## Change maded

In the class ShulkerOpenListener **(Line 54 to 67)** :

```JAVA
final Player player = (Player) event.getWhoClicked();
	if (event.getClickedInventory() != null && !event.getClickedInventory().equals(event.getWhoClicked().getInventory())) {
	if (CONFIG.getBoolean("enable-shulker-opening-in-all-inventory-type")) {
		if (!CONFIG.getBoolean("opening-from-inventory.open-from-enderchest") && event.getClickedInventory().equals(event.getWhoClicked().getEnderChest())) return;
	} else {
		if (!event.getClickedInventory().equals(event.getWhoClicked().getEnderChest())) return;
		if (!CONFIG.getBoolean("opening-from-inventory.open-from-enderchest") && event.getClickedInventory().equals(event.getWhoClicked().getEnderChest())) return;
	}
}
```

In config.yml  :

```YAML
# If this is true then player can open shulkers from all type of inventory (chest, trapped chest, dispenser, etc.)
enable-shulker-opening-in-all-inventory-type: false 
```