### PR TITLE
Fix items disappearing when player has item in offhand

### DIFF
--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
@@ -15,6 +15,7 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 
@@ -35,7 +36,7 @@ public class ShulkerOpenListener implements Listener {
             event.getPlayer().closeInventory();
         }
 
-        if (event.getAction() != Action.RIGHT_CLICK_AIR) return;
+        if (event.getAction() != Action.RIGHT_CLICK_AIR || event.getHand() != EquipmentSlot.HAND) return;
 
         final Player player = event.getPlayer();
         if (openShulker(player, player.getInventory().getItemInMainHand())) event.setCancelled(true);


### PR DESCRIPTION
Previously if you had auto clearing enabled and held something in offhand, opening the shulker from your hand made contents of the shulker disappear. This PR fixes it by checking the hand in the event.