### PR TITLE
Fixed wrongly adding a UUID when player drop shulker box.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+# This workflow will build a Java project with Maven, and cache/restore any dependencies to improve the workflow execution time
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-java-with-maven
+
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+
+name: build
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up JDK 17
+      uses: actions/setup-java@v4
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+        cache: maven
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml
+
+    - name: Upload a Build Artifact
+      uses: actions/upload-artifact@v4.6.0
+      with:
+          path: target/*.jar

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/PlayerDropItemListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/PlayerDropItemListener.java
@@ -14,7 +14,7 @@ public class PlayerDropItemListener implements Listener {
     @EventHandler (ignoreCancelled = true)
     public void onDrop(@NotNull PlayerDropItemEvent event) {
         ItemStack it = event.getItemDrop().getItemStack();
-        if (!ShulkerUtils.isShulker(it)) return;
+        if (!ShulkerUtils.isShulker(it) || ShulkerUtils.getShulkerUUID(it) == null) return;
 
         final String name = ShulkerUtils.getShulkerName(it);
         final Shulkerbox shulkerbox = Shulkerboxes.getShulker(it, name);


### PR DESCRIPTION
When a player drops an unopened Shulker box without a UUID nbt, the box will have a new UUID when picked up again, which causes each Shulker box NBT to be different