### PR TITLE
Added new config switch to optionally disable chat notifications

### DIFF
--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/InventoryClickListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/InventoryClickListener.java
@@ -81,7 +81,9 @@ public class InventoryClickListener implements Listener {
         final Shulkerbox shulker = ShulkerUtils.hasShulkerOpen((Player) event.getPlayer());
         if (shulker == null) return;
 
-        MessageUtils.sendMsgP(event.getPlayer(), "close.message", Collections.singletonMap("%name%", shulker.getTitle()));
+        if (CONFIG.getBoolean("dsiplay-close-message")) {
+            MessageUtils.sendMsgP(event.getPlayer(), "close.message", Collections.singletonMap("%name%", shulker.getTitle()));
+        }
 
         if (!MESSAGES.getString("close.sound").isEmpty()) {
             ((Player) event.getPlayer()).playSound(event.getPlayer().getLocation(), Sound.valueOf(MESSAGES.getString("close.sound")), 1f, 1f);

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
@@ -111,7 +111,9 @@ public class ShulkerOpenListener implements Listener {
             shulkerbox.updateReference();
             shulkerbox.openShulkerFor(player);
 
-            MessageUtils.sendMsgP(player, "open.message", Collections.singletonMap("%name%", shulkerbox.getTitle()));
+            if (CONFIG.getBoolean("display-open-message")) {
+                MessageUtils.sendMsgP(player, "open.message", Collections.singletonMap("%name%", shulkerbox.getTitle()));
+            }
 
             if (!MESSAGES.getString("open.sound").isEmpty()) {
                 player.playSound(player.getLocation(), Sound.valueOf(MESSAGES.getString("open.sound")), 1f, 1f);

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -12,6 +12,12 @@ prefix: "&#CC00FF&lAxShulkers &7» "
 # this also force disables 'enable-obfuscation'
 auto-clear-shulkers: false
 
+# if this is on, it will send a message to the player when a shulker box has been opened
+display-open-message: true
+
+# if this is on, the plugin will send a message to the player when a shulker box has been closed
+dsiplay-close-message: true
+
 # this setting is not reloadable, you have to restart the server
 # how often should the plugin save shulker boxes from ram to the database?
 # this is in minutes


### PR DESCRIPTION
Added a simple config switch to make it possible to disable the chat notification when opening and/or closing boxes. 