### PR TITLE
Add optional stackable empty shulker support

### DIFF
--- a/src/main/java/com/artillexstudios/axshulkers/AxShulkers.java
+++ b/src/main/java/com/artillexstudios/axshulkers/AxShulkers.java
@@ -16,6 +16,7 @@ import com.artillexstudios.axshulkers.listeners.Listeners;
 import com.artillexstudios.axshulkers.safety.SafetyManager;
 import com.artillexstudios.axshulkers.schedulers.AutoSaveScheduler;
 import com.artillexstudios.axshulkers.utils.ColorUtils;
+import com.artillexstudios.axshulkers.utils.StackableShulkerSupport;
 import com.artillexstudios.axshulkers.utils.UpdateNotifier;
 import com.tcoded.folialib.FoliaLib;
 import com.tcoded.folialib.impl.PlatformScheduler;
@@ -96,6 +97,7 @@ public final class AxShulkers extends JavaPlugin {
         database.setup();
         databaseQueue = new DatabaseQueue("AxShulkers-Datastore-thread");
         Listeners.register();
+        StackableShulkerSupport.scanOnlinePlayers();
         AutoSaveScheduler.start();
         SafetyManager.start();
 

--- a/src/main/java/com/artillexstudios/axshulkers/cache/Shulkerboxes.java
+++ b/src/main/java/com/artillexstudios/axshulkers/cache/Shulkerboxes.java
@@ -2,6 +2,7 @@ package com.artillexstudios.axshulkers.cache;
 
 import com.artillexstudios.axshulkers.AxShulkers;
 import com.artillexstudios.axshulkers.utils.ShulkerUtils;
+import com.artillexstudios.axshulkers.utils.StackableShulkerSupport;
 import org.bukkit.Bukkit;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.inventory.Inventory;
@@ -32,6 +33,9 @@ public class Shulkerboxes {
     @Nullable
     public static Shulkerbox getShulker(@NotNull ItemStack it, @NotNull String name) {
         if (!ShulkerUtils.isShulker(it)) return null;
+        if (ShulkerUtils.shouldIgnoreStackedShulker(it)) return null;
+        // Any shulker AxShulkers manages gets a unique backing inventory, so it must not merge with other items.
+        StackableShulkerSupport.makeUnstackable(it);
         final UUID uuid = ShulkerUtils.getShulkerUUID(it);
 
         if (uuid == null) {

--- a/src/main/java/com/artillexstudios/axshulkers/commands/Commands.java
+++ b/src/main/java/com/artillexstudios/axshulkers/commands/Commands.java
@@ -7,6 +7,7 @@ import com.artillexstudios.axshulkers.utils.ColorUtils;
 import com.artillexstudios.axshulkers.utils.MessageUtils;
 import com.artillexstudios.axshulkers.utils.PermissionUtils;
 import com.artillexstudios.axshulkers.utils.ShulkerUtils;
+import com.artillexstudios.axshulkers.utils.StackableShulkerSupport;
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
@@ -32,6 +33,7 @@ public class Commands implements CommandExecutor {
 
                 AxShulkers.getAbstractConfig().reloadConfig();
                 AxShulkers.getAbstractMessages().reloadConfig();
+                StackableShulkerSupport.scanOnlinePlayers();
 
                 for (Shulkerbox shulkerbox : Shulkerboxes.getShulkerMap().values()) {
                     AxShulkers.getDB().updateShulker(shulkerbox.getShulkerInventory().getContents(), shulkerbox.getUUID());

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/Listeners.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/Listeners.java
@@ -11,6 +11,7 @@ import com.artillexstudios.axshulkers.listeners.impl.PlayerDropItemListener;
 import com.artillexstudios.axshulkers.listeners.impl.PlayerInteractListener;
 import com.artillexstudios.axshulkers.listeners.impl.PlayerMoveListener;
 import com.artillexstudios.axshulkers.listeners.impl.ShulkerOpenListener;
+import com.artillexstudios.axshulkers.listeners.impl.StackableShulkerListener;
 import org.bukkit.plugin.PluginManager;
 
 public class Listeners {
@@ -28,5 +29,6 @@ public class Listeners {
         plm.registerEvents(new EntityDeathListener(), main);
         plm.registerEvents(new PlayerMoveListener(), main);
         plm.registerEvents(new PlayerInteractListener(), main);
+        plm.registerEvents(new StackableShulkerListener(), main);
     }
 }

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/BlockDispenseListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/BlockDispenseListener.java
@@ -33,6 +33,9 @@ public class BlockDispenseListener implements Listener {
             return;
         }
 
+        // Stacked empty shulkers are not AxShulkers-managed; dispense them with normal server behavior.
+        if (ShulkerUtils.shouldIgnoreStackedShulker(event.getItem())) return;
+
         if (event.getItem().getAmount() != 1) {
             event.getItem().setAmount(1);
             event.setCancelled(true);

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/BlockPlaceListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/BlockPlaceListener.java
@@ -32,6 +32,9 @@ public class BlockPlaceListener implements Listener {
             return;
         }
 
+        // Let normal item handling process intentionally stackable empty shulkers.
+        if (ShulkerUtils.shouldIgnoreStackedShulker(event.getItemInHand())) return;
+
         if (event.getItemInHand().getAmount() != 1) {
             event.setCancelled(true);
             event.getItemInHand().setAmount(1);

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/EntityDeathListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/EntityDeathListener.java
@@ -26,6 +26,9 @@ public class EntityDeathListener implements Listener {
             return;
         }
 
+        // Stacked empty shulker item entities are ordinary items, not AxShulkers-managed containers.
+        if (ShulkerUtils.shouldIgnoreStackedShulker(it)) return;
+
         String name = ShulkerUtils.getShulkerName(it);
         Shulkerbox shulkerbox = Shulkerboxes.getShulker(it, name);
         if (shulkerbox == null) return;

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/InventoryClickListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/InventoryClickListener.java
@@ -6,6 +6,7 @@ import com.artillexstudios.axshulkers.cache.Shulkerboxes;
 import com.artillexstudios.axshulkers.utils.BlacklistUtils;
 import com.artillexstudios.axshulkers.utils.MessageUtils;
 import com.artillexstudios.axshulkers.utils.ShulkerUtils;
+import com.artillexstudios.axshulkers.utils.StackableShulkerSupport;
 import org.bukkit.GameMode;
 import org.bukkit.Sound;
 import org.bukkit.entity.Player;
@@ -88,6 +89,8 @@ public class InventoryClickListener implements Listener {
         }
 
         ShulkerUtils.setShulkerContents(shulker.getItem(), event.getPlayer().getOpenInventory().getTopInventory(), false);
+        // If the player emptied this shulker, drop AxShulkers tracking and make it stackable again.
+        if (StackableShulkerSupport.migrateClosedShulker(shulker)) return;
 
         if (CONFIG.getBoolean("enable-obfuscation", false) || (!CONFIG.getBoolean("auto-clear-shulkers", false) && !(CONFIG.getBoolean("auto-clear-in-creative", true) && event.getPlayer().getGameMode().equals(GameMode.CREATIVE)))) return;
 

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/PlayerDropItemListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/PlayerDropItemListener.java
@@ -15,6 +15,8 @@ public class PlayerDropItemListener implements Listener {
     public void onDrop(@NotNull PlayerDropItemEvent event) {
         ItemStack it = event.getItemDrop().getItemStack();
         if (!ShulkerUtils.isShulker(it)) return;
+        // Dropped stacked empty shulkers have no AxShulkers backing inventory to save.
+        if (ShulkerUtils.shouldIgnoreStackedShulker(it)) return;
 
         String name = ShulkerUtils.getShulkerName(it);
         Shulkerbox shulkerbox = Shulkerboxes.getShulker(it, name);

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/ShulkerOpenListener.java
@@ -88,6 +88,8 @@ public class ShulkerOpenListener implements Listener {
     private boolean openShulker(@NotNull Player player, ItemStack it) {
         if (!player.hasPermission("axshulkers.use")) return false;
         if (!ShulkerUtils.isShulker(it)) return false;
+        // Stacked shulkers are normal empty items; split one off before AxShulkers manages it.
+        if (ShulkerUtils.shouldIgnoreStackedShulker(it)) return false;
         if (it.getAmount() > 1) {
             it.setAmount(1);
             return false;

--- a/src/main/java/com/artillexstudios/axshulkers/listeners/impl/StackableShulkerListener.java
+++ b/src/main/java/com/artillexstudios/axshulkers/listeners/impl/StackableShulkerListener.java
@@ -1,0 +1,63 @@
+package com.artillexstudios.axshulkers.listeners.impl;
+
+import com.artillexstudios.axshulkers.AxShulkers;
+import com.artillexstudios.axshulkers.utils.StackableShulkerSupport;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryOpenEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.jetbrains.annotations.NotNull;
+
+import static com.artillexstudios.axshulkers.AxShulkers.CONFIG;
+
+public class StackableShulkerListener implements Listener {
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onJoin(@NotNull PlayerJoinEvent event) {
+        StackableShulkerSupport.scanPlayer(event.getPlayer());
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+    public void onOpen(@NotNull InventoryOpenEvent event) {
+        if (CONFIG.getBoolean("stacked-shulker-support.scan-opened-inventories", true)) {
+            StackableShulkerSupport.scanInventory(event.getInventory());
+        }
+
+        if (event.getPlayer() instanceof Player player) {
+            StackableShulkerSupport.scanPlayer(player);
+        }
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onClick(@NotNull InventoryClickEvent event) {
+        // Wait until the click has been applied so moved shulkers are updated in their final slots.
+        AxShulkers.getScheduler().runNextTick(task -> {
+            if (event.getClickedInventory() != null) {
+                StackableShulkerSupport.scanInventory(event.getClickedInventory());
+            }
+            StackableShulkerSupport.scanInventory(event.getView().getTopInventory());
+            StackableShulkerSupport.scanInventory(event.getView().getBottomInventory());
+
+            if (event.getWhoClicked() instanceof Player player) {
+                StackableShulkerSupport.updateItem(player.getItemOnCursor());
+            }
+        });
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onDrag(@NotNull InventoryDragEvent event) {
+        // Drag events may touch several slots, so rescan the visible inventories after Bukkit applies the drag.
+        AxShulkers.getScheduler().runNextTick(task -> {
+            StackableShulkerSupport.scanInventory(event.getView().getTopInventory());
+            StackableShulkerSupport.scanInventory(event.getView().getBottomInventory());
+
+            if (event.getWhoClicked() instanceof Player player) {
+                StackableShulkerSupport.updateItem(player.getItemOnCursor());
+            }
+        });
+    }
+}

--- a/src/main/java/com/artillexstudios/axshulkers/utils/ShulkerUtils.java
+++ b/src/main/java/com/artillexstudios/axshulkers/utils/ShulkerUtils.java
@@ -69,6 +69,15 @@ public class ShulkerUtils {
         return shulkers.contains(it.getType());
     }
 
+    public static boolean isStackedShulker(@Nullable ItemStack it) {
+        return isShulker(it) && it.getAmount() > 1;
+    }
+
+    public static boolean shouldIgnoreStackedShulker(@Nullable ItemStack it) {
+        // Only bypass legacy stack normalization when the optional modern stacking support can actually run.
+        return StackableShulkerSupport.canApply() && isStackedShulker(it);
+    }
+
     public static boolean isAllowedInventoryType(@NotNull Inventory inventory) {
         return inventories.contains(inventory.getType());
     }

--- a/src/main/java/com/artillexstudios/axshulkers/utils/StackableShulkerSupport.java
+++ b/src/main/java/com/artillexstudios/axshulkers/utils/StackableShulkerSupport.java
@@ -1,0 +1,188 @@
+package com.artillexstudios.axshulkers.utils;
+
+import com.artillexstudios.axshulkers.AxShulkers;
+import com.artillexstudios.axshulkers.cache.Shulkerbox;
+import com.artillexstudios.axshulkers.cache.Shulkerboxes;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.lang.reflect.Method;
+import java.util.UUID;
+
+import static com.artillexstudios.axshulkers.AxShulkers.CONFIG;
+
+/**
+ * Keeps empty shulker stacking optional without raising AxShulkers' compile-time API requirement.
+ * Modern servers expose ItemMeta#setMaxStackSize; older servers simply leave this feature unavailable.
+ */
+public class StackableShulkerSupport {
+    private static final Method SET_MAX_STACK_SIZE = findSetMaxStackSize();
+    private static boolean warnedUnavailable = false;
+
+    @Nullable
+    private static Method findSetMaxStackSize() {
+        try {
+            return ItemMeta.class.getMethod("setMaxStackSize", Integer.class);
+        } catch (NoSuchMethodException ignored) {
+            return null;
+        }
+    }
+
+    public static boolean isAvailable() {
+        return SET_MAX_STACK_SIZE != null;
+    }
+
+    public static boolean isEnabled() {
+        return CONFIG.getBoolean("stacked-shulker-support.enabled", false);
+    }
+
+    public static boolean canApply() {
+        if (!isEnabled()) return false;
+        if (isAvailable()) return true;
+
+        if (!warnedUnavailable) {
+            warnedUnavailable = true;
+            AxShulkers.getInstance().getLogger().warning("stacked-shulker-support is enabled, but this server does not support ItemMeta#setMaxStackSize. Empty shulkers will not be made stackable.");
+        }
+        return false;
+    }
+
+    public static void scanOnlinePlayers() {
+        if (!canApply() || !CONFIG.getBoolean("stacked-shulker-support.scan-player-inventories", true)) return;
+
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            scanPlayer(player);
+        }
+    }
+
+    public static void scanPlayer(@NotNull Player player) {
+        if (!canApply() || !CONFIG.getBoolean("stacked-shulker-support.scan-player-inventories", true)) return;
+
+        scanInventory(player.getInventory());
+        scanInventory(player.getEnderChest());
+    }
+
+    public static void scanInventory(@Nullable Inventory inventory) {
+        if (!canApply() || inventory == null) return;
+
+        for (int slot = 0; slot < inventory.getSize(); slot++) {
+            updateItem(inventory.getItem(slot));
+        }
+    }
+
+    public static void updateItem(@Nullable ItemStack item) {
+        if (!canApply() || !ShulkerUtils.isShulker(item)) return;
+
+        UUID uuid = ShulkerUtils.getShulkerUUID(item);
+        if (uuid != null) {
+            handleManagedShulker(item, uuid);
+            return;
+        }
+
+        if (isEmptyShulkerItem(item)) {
+            setMaxStackSize(item, getEmptyStackSize());
+            return;
+        }
+
+        if (item.getAmount() == 1) {
+            setMaxStackSize(item, null);
+        }
+    }
+
+    public static boolean migrateClosedShulker(@NotNull Shulkerbox shulkerbox) {
+        if (!canApply() || !CONFIG.getBoolean("stacked-shulker-support.migrate-empty-managed-shulkers", true)) return false;
+        if (!isEmpty(shulkerbox.getShulkerInventory().getContents())) {
+            makeUnstackable(shulkerbox.getItem());
+            return false;
+        }
+
+        migrateEmptyManagedShulker(shulkerbox.getItem(), shulkerbox.getUUID());
+        return true;
+    }
+
+    public static void makeUnstackable(@Nullable ItemStack item) {
+        if (!canApply() || !ShulkerUtils.isShulker(item)) return;
+        if (item.getAmount() != 1) return;
+
+        setMaxStackSize(item, null);
+    }
+
+    private static void handleManagedShulker(@NotNull ItemStack item, @NotNull UUID uuid) {
+        if (!CONFIG.getBoolean("stacked-shulker-support.migrate-empty-managed-shulkers", true)) {
+            makeUnstackable(item);
+            return;
+        }
+
+        Shulkerbox cached = Shulkerboxes.getShulkerMap().get(uuid);
+        if (cached != null) {
+            // Open shulkers are still actively managed; migrate them only after the view closes.
+            if (!cached.getShulkerInventory().getViewers().isEmpty()) return;
+
+            if (isEmpty(cached.getShulkerInventory().getContents())) {
+                migrateEmptyManagedShulker(item, uuid);
+            } else {
+                makeUnstackable(item);
+            }
+            return;
+        }
+
+        // Fall back to the database for managed shulkers that are not currently cached in memory.
+        ItemStack[] storedItems = AxShulkers.getDB().getShulker(uuid);
+        if (storedItems == null) {
+            makeUnstackable(item);
+            return;
+        }
+
+        if (isEmpty(storedItems)) {
+            migrateEmptyManagedShulker(item, uuid);
+        } else {
+            makeUnstackable(item);
+        }
+    }
+
+    private static void migrateEmptyManagedShulker(@NotNull ItemStack item, @NotNull UUID uuid) {
+        // Empty shulkers do not need AxShulkers UUID/database tracking; removing it lets matching items stack again.
+        ShulkerUtils.clearShulkerContents(item);
+        ShulkerUtils.removeShulkerUUID(item);
+        Shulkerboxes.removeShulkerbox(uuid);
+        AxShulkers.getDatabaseQueue().submit(() -> AxShulkers.getDB().removeShulker(uuid));
+        setMaxStackSize(item, getEmptyStackSize());
+    }
+
+    private static boolean isEmptyShulkerItem(@NotNull ItemStack item) {
+        return isEmpty(ShulkerUtils.getShulkerItems(item));
+    }
+
+    public static boolean isEmpty(@Nullable ItemStack[] items) {
+        if (items == null) return true;
+
+        for (ItemStack item : items) {
+            if (item == null || item.getType() == Material.AIR || item.getAmount() <= 0) continue;
+            return false;
+        }
+        return true;
+    }
+
+    private static int getEmptyStackSize() {
+        int configured = CONFIG.getInt("stacked-shulker-support.empty-stack-size", 64);
+        return Math.max(1, Math.min(99, configured));
+    }
+
+    private static void setMaxStackSize(@NotNull ItemStack item, @Nullable Integer maxStackSize) {
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null || SET_MAX_STACK_SIZE == null) return;
+
+        try {
+            SET_MAX_STACK_SIZE.invoke(meta, maxStackSize);
+            item.setItemMeta(meta);
+        } catch (Exception ex) {
+            AxShulkers.getInstance().getLogger().warning("Failed to update shulker max_stack_size: " + ex.getMessage());
+        }
+    }
+}

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -27,6 +27,53 @@ opening-from-inventory:
   # should this also be possible in the player's ender chest?
   open-from-enderchest: true
 
+# Optional support for servers that intentionally allow empty shulker boxes to stack.
+# This uses the modern item max_stack_size component through ItemMeta#setMaxStackSize.
+# Version requirement:
+# - Works on modern component-capable servers that provide ItemMeta#setMaxStackSize, such as Paper/Purpur 1.20.5+.
+# - Works on 26.2 servers.
+# - Does not work on older servers without that method.
+# AxShulkers still compiles against older server APIs. If this is enabled on an unsupported server,
+# AxShulkers logs a warning, ignores this section, and keeps its normal behavior.
+#
+# When enabled, AxShulkers owns the empty-shulker stacking behavior:
+# - empty shulker boxes are given a max stack size
+# - filled shulker boxes are kept unstackable
+# - shulker ItemStacks with an amount greater than 1 are ignored by AxShulkers' open/database logic
+# - AxShulkers-managed shulkers that are empty in the database are migrated back to normal stackable empty shulkers
+#
+# Important behavior notes:
+# - Only empty shulkers are made stackable.
+# - Shulkers only stack with other shulkers whose item data matches, including name, lore, color, and components.
+# - Offline player inventories are not scanned directly; they are updated when the player next joins.
+# - If this feature is disabled, AxShulkers leaves any existing max_stack_size components alone.
+stacked-shulker-support:
+  # Master switch for this feature.
+  # Leave this false unless your server intentionally supports stackable empty shulkers.
+  # Set this true if you want AxShulkers to replace the stackable-shulker datapack behavior.
+  enabled: false
+
+  # Max stack size applied to empty shulker boxes.
+  # Minecraft currently accepts values from 1 to 99; AxShulkers clamps this value into that range.
+  # Use 64 for normal item-stack behavior.
+  empty-stack-size: 64
+
+  # If true, AxShulkers will clean up its own database entries for shulkers that are now empty.
+  # This fixes the case where an empty shulker was previously opened by AxShulkers and therefore still has an AxShulkers UUID.
+  # When an empty managed shulker is found, AxShulkers removes its UUID, deletes the database entry, clears stored contents,
+  # and applies the configured empty stack size so it can merge with matching empty shulkers again.
+  # Filled managed shulkers are never migrated.
+  migrate-empty-managed-shulkers: true
+
+  # If true, AxShulkers scans online players' inventories and ender chests.
+  # Scans run when the plugin enables, when /axshulkers reload is used, when a player joins,
+  # and after inventory clicks/drags that may have moved shulkers.
+  scan-player-inventories: true
+
+  # If true, AxShulkers scans inventories that players open, such as chests, barrels, hoppers, and shulker-box inventories.
+  # This updates stored containers gradually as players actually look inside them instead of scanning every container in the world.
+  scan-opened-inventories: true
+
 # if this is true then players won't be able to open shulkers from their hand
 disable-shulker-opening: false
 # if this is true then players won't be able to place them down (they can still open them)
@@ -93,4 +140,4 @@ update-notifier:
 enable-safety: true
 
 # do not change this
-version: 13
+version: 14


### PR DESCRIPTION
## Summary

Adds optional support for servers that intentionally allow empty shulker boxes to stack.

When enabled, AxShulkers can:
- apply a configurable max stack size to empty shulker boxes
- keep filled shulker boxes unstackable
- ignore stacked shulker ItemStacks in AxShulkers open/database logic
- migrate empty AxShulkers-managed shulkers out of the database/cache so they can stack again
- scan online player inventories, ender chests, and opened inventories gradually

The feature is disabled by default.

## Compatibility

This preserves AxShulkers' current old compile-time API target by using reflection for `ItemMeta#setMaxStackSize`.

If the runtime server does not provide that API, the feature logs a warning and does not apply stackable behavior. Existing behavior remains unchanged unless the feature is enabled and supported at runtime.

## Config

Adds:

```yaml
stacked-shulker-support:
  enabled: false
  empty-stack-size: 64
  migrate-empty-managed-shulkers: true
  scan-player-inventories: true
  scan-opened-inventories: true
```

The config comments explain the behavior, runtime requirements, and each option.

## Notes

This is intended for modern Paper/Purpur servers using item components or equivalent behavior to allow empty shulkers to stack while filled shulkers remain unstackable.

Related issue: Artillex-Studios/Issues#1184

## Testing

- Built successfully with Maven using `-DskipTests`.
- Tested locally on a Purpur 26.2 server fork before preparing the PR.